### PR TITLE
Batch size

### DIFF
--- a/neasqc_wp61/6_Classify_With_Quantum_Model.sh
+++ b/neasqc_wp61/6_Classify_With_Quantum_Model.sh
@@ -68,7 +68,7 @@ python3.10 ./data/data_processing/use_pre_alpha.py -s ${seed} -op ${optimiser} -
 elif [[ "${model}" == "pre_alpha_lambeq" ]]
 then
 echo "running pre_alpha_lambeq"
-python3.10 ./data/data_processing/use_pre_alpha_lambeq.py -s ${seed} -op ${optimiser} -i ${iterations} -r ${runs} -tr ${train} -te ${test} -o ${outfile} -an ${ansatz} -qn ${qn} -nl ${nl} -np ${np}
+python3.10 ./data/data_processing/use_pre_alpha_lambeq.py -s ${seed} -op ${optimiser} -i ${iterations} -r ${runs} -tr ${train} -te ${test} -o ${outfile} -an ${ansatz} -qn ${qn} -nl ${nl} -np ${np} -b ${b}
 elif [[ "${model}" == "alpha_pennylane" ]]
 then
 echo "running alpha_pennylane"

--- a/neasqc_wp61/benchmarking/hpc/generate_slurm_scripts.py
+++ b/neasqc_wp61/benchmarking/hpc/generate_slurm_scripts.py
@@ -36,20 +36,20 @@ def main():
             f2.write(filled_template)
           
       elif params[0] == 'pre_alpha_lambeq':
-        if len(params) != 9: 
+        if len(params) != 10: 
           print("WARNING: line " + str(j) + " in your text file has the wrong number of parameters for the chosen model. This line will be skipped.")
           continue
         else:
           '''
           If model is pre-alpha lambeq, create a SLURM script whose name is in the format
-          pre_alpha_lambeq_[seed]_[optimiser]_[iterations]_[runs]_[ansatz]_[qubits per noun]_[number of circuit layers]_[number of single qubit params].sh
+          pre_alpha_lambeq_[seed]_[optimiser]_[iterations]_[runs]_[ansatz]_[qubits per noun]_[number of circuit layers]_[number of single qubit params]_[batch size].sh
           '''
           slurm_template = "slurm_templates/pre_alpha_lambeq.sh"
           with open(slurm_template, 'r') as f1:
             template = Template(f1.read())
-          s, p, i, r, an, qn, nl, np = params[1:]
-          filled_template = template.render(s=s, r=r, i=i, p=p, an=an, qn=qn,nl=nl,np=np)
-          with open(f'slurm_scripts/pre_alpha_lambeq_{s}_{p}_{i}_{r}_{an}_{qn}_{nl}_{np}.sh','w') as f2:
+          s, p, i, r, an, qn, nl, np, b = params[1:]
+          filled_template = template.render(s=s, r=r, i=i, p=p, an=an, qn=qn,nl=nl,np=np, b=b)
+          with open(f'slurm_scripts/pre_alpha_lambeq_{s}_{p}_{i}_{r}_{an}_{qn}_{nl}_{np}_{b}.sh','w') as f2:
             f2.write(filled_template)
     
       #elif params[0] = 'alpha'

--- a/neasqc_wp61/benchmarking/hpc/slurm_templates/pre_alpha_lambeq.sh
+++ b/neasqc_wp61/benchmarking/hpc/slurm_templates/pre_alpha_lambeq.sh
@@ -5,13 +5,13 @@
 #SBATCH -p GpuQ
 #SBATCH -N 1
 #SBATCH -t 01:00:00
-#SBATCH --job-name=pre_alpha_lambeq_{{ s }}_{{ p }}_{{ i }}_{{ r }}_{{ an }}_{{ qn }}_{{ nl }}_{{ np }}
+#SBATCH --job-name=pre_alpha_lambeq_{{ s }}_{{ p }}_{{ i }}_{{ r }}_{{ an }}_{{ qn }}_{{ nl }}_{{ np }}_{{ b }}
    
 # Charge job to my project 
 #SBATCH -A iccom018c
 
 # Write stdout+stderr to file
-#SBATCH -o slurm_output/pre_alpha_lambeq_{{ s }}_{{ p }}_{{ i }}_{{ r }}_{{ an }}_{{ qn }}_{{ nl }}_{{ np }}.txt
+#SBATCH -o slurm_output/pre_alpha_lambeq_{{ s }}_{{ p }}_{{ i }}_{{ r }}_{{ an }}_{{ qn }}_{{ nl }}_{{ np }}_{{ b }}.txt
 
 # Mail me on job start & end
 #SBATCH --mail-user=pablo.suarez@ichec.ie
@@ -33,6 +33,7 @@ module load cuda/11.4
 # -r : number of runs of the model
 # -i : number of iterations of the optmiser
 # -p : choice of optimiser
+# -b : batch size for GPU processing 
 # -a : choice of ansatz
 # -q : number of qubits per noun type
 # -n: number of layers in the quantum circuit
@@ -41,6 +42,6 @@ module load cuda/11.4
 
 echo "`date +%T`"
 
-bash 6_Classify_With_Quantum_Model.sh -m pre_alpha_lambeq -t ./data/datasets/reduced_amazonreview_pre_alpha_train.tsv -v ./data/datasets/reduced_amazonreview_pre_alpha_test.tsv -s {{ s }} -p {{ p }}  -i {{ i }} -r {{ r }} -a {{ an }} -q {{ qn }} -n {{ nl }} -x {{ np }} -o ./benchmarking/results/raw/
+bash 6_Classify_With_Quantum_Model.sh -m pre_alpha_lambeq -t ./data/datasets/reduced_amazonreview_pre_alpha_train.tsv -v ./data/datasets/reduced_amazonreview_pre_alpha_test.tsv -s {{ s }} -p {{ p }} -i {{ i }} -r {{ r }} -a {{ an }} -q {{ qn }} -n {{ nl }} -x {{ np }} -b {{ b }} -o ./benchmarking/results/raw/
 
 echo "`date +%T`"

--- a/neasqc_wp61/benchmarking/hpc/slurm_templates/pre_alpha_lambeq.sh
+++ b/neasqc_wp61/benchmarking/hpc/slurm_templates/pre_alpha_lambeq.sh
@@ -33,7 +33,7 @@ module load cuda/11.4
 # -r : number of runs of the model
 # -i : number of iterations of the optmiser
 # -p : choice of optimiser
-# -b : batch size for GPU processing 
+# -b : batch size for GPU processing (set to 0 for default or when using CPU)
 # -a : choice of ansatz
 # -q : number of qubits per noun type
 # -n: number of layers in the quantum circuit


### PR DESCRIPTION
## Scope
Incorporates the necessary changes to the code to be able to generate SLURM scripts for pre_alpha_lambeq that contain the new variable 'batch size', and for this variable to be introduced as an additional flag when calling this model.


## Implementation
Very small changes made to the SLURM script generator, the SLURM script template, and the bash file for step 6.

## How to Test
To test, add your batch size as the last parameter when writing your parameters for pre_alpha_lambeq in the benchmark_params.txt file. Write 0 to set the batch size to its default value (i.e. the entire dataset), especially if you are only using CPUs. Then run generate_slurm_scripts.py. This will generate a corresponding SLURM script for the chosen set of parameters. The batch size should appear under the flag -b. Submit this script to your HPC system's queue. In the output log file you will see the batch size that you stated printed in the list of input parameters.
