### PR TITLE
Fixes flag incompatibility stemming from Beta bash script.

### DIFF
--- a/neasqc_wp61/6_Beta.sh
+++ b/neasqc_wp61/6_Beta.sh
@@ -16,8 +16,9 @@ done
 
 echo "train: $train";
 echo "test: $test";
+echo "dimension of PCA-reduced input embeddings: $dimension";
 echo "K values for KNN algorithm: ${k[*]}";
 echo "output: $output";
 
 echo "running beta_1"
-python3.10 ./data/data_processing/use_beta_1.py -tr ${train} -te ${test} -d ${dimension} -k ${k[*]} -o ${output}s
+python3.10 ./data/data_processing/use_beta_1.py -tr ${train} -te ${test} -pca ${dimension} -k ${k[*]} -o ${output}s


### PR DESCRIPTION
Fixes an issue with the Beta bash script that would prevent it from successfully calling the use_beta_1.py script. To test simply call the beta bash script as usual, this should start the Beta 1 model with no errors