### PR TITLE
Embeddings modularity

### DIFF
--- a/neasqc_wp61/models/quantum/embedder.py
+++ b/neasqc_wp61/models/quantum/embedder.py
@@ -1,0 +1,321 @@
+"""
+Embedder
+============
+Module containing the base class for transforming sentences in a dataset into embeddings
+"""
+
+from abc import ABC, abstractmethod
+import pandas as pd
+from pandas.core.api import DataFrame as DataFrame
+from transformers import BertTokenizer, BertModel
+import torch
+import numpy as np
+import fasttext as ft
+import fasttext.util
+
+
+class Embedder(ABC):
+    """
+    Base class for the generation of embeddings for the sentences
+    comprising a dataset.
+    """
+
+    def __init__(self, dataset: DataFrame, sentence_or_word: bool = True) -> None:
+        """
+        Initialises the embedder class
+
+        Parameters
+        ----------
+        dataset : pd.DataFrame
+            Pandas dataset. Each row of the dataset correspods to a
+            sentence.
+        sentence_or_word : bool
+            A bool controllig whether we want to produce a sentence
+            embedding or word embedding vector for each sentence in the
+            dataset. True is for sentence embedding, False is for word
+            embedding.
+        """
+
+        self.dataset = dataset
+        self.sentence_or_word = sentence_or_word
+
+    @abstractmethod
+    def compute_embeddings(self) -> DataFrame:
+        """
+        Creates embeddings for sentences in a dataset
+
+        Returns
+        -------
+        pd.DataFrame
+            A pandas dataframe with the same structure as the original
+            dataset, but with an additional column containing the
+            embeddings corresponding to the sentence contained in each
+            row.
+        """
+        pass
+
+    @abstractmethod
+    def save_embedding_dataset(self, path: str, filename: str) -> None:
+        """
+        Saves the dataset containing the embeddings as a TSV file.
+
+        Parameters
+        ----------
+        path : str
+            The path to the location where the user wishes to save the
+            generated dataset containing the embeddings (it should not
+            include a / at the end).
+        filename: str
+            The name with which the generated dataset containing the
+            embeddings will be saved (it should not include .csv or any
+            other file extension).
+        """
+        self.dataset.to_csv(path + "/" + filename + ".tsv", index=False, sep="\t")
+
+
+class Bert(Embedder):
+    """
+    Class for generating BERT embeddings
+    """
+
+    def __init__(
+        self,
+        dataset: DataFrame,
+        sentence_or_word: bool = True,
+        cased_or_uncased: bool = False,
+        **kwargs
+    ) -> None:
+        """
+        Initialises the BERT embedder class
+
+        Parameters
+        ----------
+        dataset : pd.DataFrame
+            Pandas dataset. Each row of the dataset correspods to a
+            sentence.
+        sentence_or_word : bool
+            States whether we want to produce a sentence embedding or
+            word embedding vector for each sentence in the dataset. True
+            is for sentence embedding, False is for word embedding.
+        case_or_uncased: bool
+            States whether we want to work with BERT's cased or uncased
+            pretrained base model. True is for cased, False is for
+            uncased.
+        **kwargs
+            Additional arguments to be passed to the BertTokenizer
+            object. These can be found in
+            https://huggingface.co/docs/transformers/main_classes/tokenizer#transformers.PreTrainedTokenizer
+        """
+        super().__init__(dataset, sentence_or_word)
+        self.cased_or_uncased = cased_or_uncased
+        self.kwargs = kwargs
+
+    def compute_embeddings(self, **kwargs) -> DataFrame:
+        """
+        Creates BERT embeddings for sentences in a dataset
+
+        Parameters
+        ----------
+        **kwargs
+            Additional arguments to be passed to the BertTokenizer
+            object. These can be found in
+            https://huggingface.co/docs/transformers/main_classes/tokenizer#transformers.PreTrainedTokenizer
+
+        Returns
+        -------
+        embeddings_df : pd.DataFrame
+            A pandas dataframe with the same structure as the original
+            dataset, but with an additional column containing the
+            BERT embeddings corresponding to the sentence contained in each
+            row.
+        """
+
+        embeddings_df = self.dataset.copy()
+        embeddings_df.columns = ["class", "sentence", "sentence_structure"]
+
+        if self.cased_or_uncased:
+            tokenizer = BertTokenizer.from_pretrained("bert-base-cased", **kwargs)
+            bert_model = BertModel.from_pretrained("bert-base-cased")
+
+        else:
+            tokenizer = BertTokenizer.from_pretrained("bert-base-uncased", **kwargs)
+            bert_model = BertModel.from_pretrained("bert-base-uncased")
+
+        for param in bert_model.parameters():
+            param.requires_grad = False
+        bert_model.eval()
+
+        if self.sentence_or_word:
+            print("Generating sentence embeddings. Please wait...")
+            vectorised_sentence_list = []
+            for sentence in embeddings_df.sentence.values:
+                inputs = tokenizer.encode_plus(sentence).input_ids
+                inputs = torch.LongTensor(inputs)
+
+                with torch.no_grad():
+                    sentence_embedding = (
+                        bert_model(inputs.unsqueeze(0))[1]
+                        .squeeze(0)
+                        .cpu()
+                        .detach()
+                        .numpy()
+                    )
+                vectorised_sentence_list.append(
+                    [tensor.item() for tensor in sentence_embedding]
+                )
+
+            embeddings_df["sentence_vectorised"] = vectorised_sentence_list
+
+            print("Done!")
+
+        else:
+            print("Generating word embeddings. Please wait...")
+            vectorised_sentence_list = []
+            for sentence in embeddings_df.sentence.values:
+                # List storing the word embeddings of each word in a sentence
+                sentence_word_embeddings = []
+                for word in sentence.split():
+                    inputs = tokenizer.encode_plus(word).input_ids
+                    inputs = torch.LongTensor(inputs)
+
+                    with torch.no_grad():
+                        word_embedding = (
+                            bert_model(inputs.unsqueeze(0))[1]
+                            .squeeze(0)
+                            .cpu()
+                            .detach()
+                            .numpy()
+                        )
+
+                    sentence_word_embeddings.append(word_embedding.tolist())
+                vectorised_sentence_list.append(sentence_word_embeddings)
+
+            embeddings_df["sentence_vectorised"] = vectorised_sentence_list
+            print("Done!")
+
+        self.dataset = embeddings_df
+
+        return self.dataset
+
+    def save_embedding_dataset(self, path: str, filename: str) -> None:
+        """
+        Saves the dataset containing the BERT embeddings as a CSV file.
+
+        Parameters
+        ----------
+        path : str
+            The path to the location where the user wishes to save the
+            generated dataset containing the embeddings.
+        filename: str
+            The name with which the generated dataset containing the
+            embeddings will be saved (it should not include .csv or any
+            other file extension).
+        """
+        super().save_embedding_dataset(path, filename)
+
+
+class FastText(Embedder):
+    """
+    Class for generating FastText embeddings
+    """
+
+    def __init__(
+        self,
+        dataset: DataFrame,
+        sentence_or_word: bool = True,
+        dim: int = 300,
+        cased_or_uncased: bool = True,
+    ) -> None:
+        """
+        Initialises the FastText embedder class
+
+        Parameters
+        ----------
+        dataset : pd.DataFrame
+            Pandas dataset. Each row of the dataset correspods to a
+            sentence.
+        sentence_or_word : bool
+            States whether we want to produce a sentence embedding or word
+            embedding vector for each sentence in the dataset. True is for
+            sentence embedding, False is for word embedding.
+        dim : int
+            The output dimension of FastText's word/sentence vectors.
+            Default value is 300, but can be set to any value below that.
+        case_or_uncased: bool
+            Controls whether we casefold our input sentences before
+            vectorising them using FastText. FastText's pretrained model is
+            case sensitive so casefolding will produce different embeddings.
+        """
+
+        super().__init__(dataset, sentence_or_word)
+        self.dim = dim
+        self.cased_or_uncased = cased_or_uncased
+
+    def compute_embeddings(self) -> DataFrame:
+        """
+        Creates FastText embeddings for sentences in a dataset
+
+        Returns
+        -------
+        embeddings_df : pd.DataFrame
+            A pandas dataframe with the same structure as the original
+            dataset, but with an additional column containing the
+            FastText embeddings corresponding to the sentence contained
+            in each row.
+        """
+        fasttext.util.download_model("en", if_exists="ignore")
+        model = ft.load_model("cc.en.300.bin")
+        if self.dim < 300:
+            fasttext.util.reduce_model(model, self.dim)
+        elif self.dim > 300:
+            print("Error: dimension must be <= 300")
+            return
+
+        embeddings_df = self.dataset.copy()
+        embeddings_df.columns = ["class", "sentence", "sentence_structure"]
+
+        if self.sentence_or_word:
+            print("Generating sentence embeddings. Please wait...")
+            vectorised_sentence_list = []
+            for sentence in embeddings_df.sentence.values:
+                if not self.cased_or_uncased:
+                    sentence = sentence.casefold()
+                sentence_embedding = model.get_sentence_vector(sentence).tolist()
+                vectorised_sentence_list.append(sentence_embedding)
+
+            embeddings_df["sentence_vectorised"] = vectorised_sentence_list
+            print("Done!")
+
+        else:
+            print("Generating word embeddings. Please wait...")
+            vectorised_sentence_list = []
+            for sentence in embeddings_df.sentence.values:
+                word_embeddings_list = []
+                for word in sentence.split():
+                    word_embedding = model.get_word_vector(word).tolist()
+                    word_embeddings_list.append(word_embedding)
+                vectorised_sentence_list.append(word_embeddings_list)
+
+            embeddings_df["sentence_vectorised"] = vectorised_sentence_list
+            print("Done!")
+
+        self.dataset = embeddings_df
+
+        return self.dataset
+
+    def save_embedding_dataset(self, path: str, filename: str) -> None:
+        """
+        Saves the dataset containing the FastText embeddings as a CSV
+        file.
+
+        Parameters
+        ----------
+        path : str
+            The path to the location where the user wishes to save the
+            generated dataset containing the embeddings.
+         filename: str
+            The name with which the generated dataset containing the
+            embeddings will be saved (it should not include .csv or any
+            other file extension).
+        """
+        super().save_embedding_dataset(path, filename)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ qiskit = "==0.43.1"
 qiskit_ignis = "==0.7.1"
 sympy = "==1.11.1"
 torch = "==2.0.1"
+fasttext = { git = "https://github.com/cfculhane/fastText.git" }
+transformers = "==4.24.0"
 tensorflow = {version = "==2.10.0", markers = "platform_machine != 'arm64'"}
 tensorflow-macos = {version = "==2.10.0", markers = "sys_platform == 'darwin' and platform_machine == 'arm64'"}
 tensorflow-metal = {version = "==0.6.0", markers = "sys_platform == 'darwin' and platform_machine == 'arm64'"}

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -1,0 +1,354 @@
+import unittest
+import pandas as pd
+import numpy as np
+import random
+import os
+import sys
+
+current_path = os.path.dirname(os.path.abspath(__file__))
+dataset_path = current_path + "/../neasqc_wp61/data/datasets/"
+sys.path.append(current_path + "/../neasqc_wp61/models/quantum/")
+from embedder import *
+
+# Define helper functions
+
+
+def is_sentence_embedding(x: list) -> bool:
+    """
+    Checks if a list is of type list[float], the expected type for
+    a sentence embedding.
+
+    Parameters
+    ----------
+    x: list
+        The list to check.
+
+    Returns
+    -------
+    bool
+        True if x is of type list[list[float]], False otherwise.
+    """
+
+    if isinstance(x, list):
+        return all(isinstance(element, float) for element in x)
+    return False
+
+
+def is_word_embedding(x: list) -> bool:
+    """
+    Checks if a list is of type list[list[float]], the expected type for
+    a word embedding.
+
+    Parameters
+    ----------
+    x: list
+        The list to check.
+
+    Returns
+    -------
+    bool
+        True if x is of type list[list[float]], False otherwise.
+    """
+
+    if isinstance(x, list):
+        if all(isinstance(sublist, list) for sublist in x):
+            return all(
+                isinstance(element, float) for sublist in x for element in sublist
+            )
+    return False
+
+
+def str_to_sentence_embedding(x: str) -> list[float]:
+    """
+    Converts a string into a list of floats. Helps read sentence
+    embeddings off a TSV file.
+
+    Parameters
+    ----------
+    x: str
+        The str that we wish to convert to a readable sentence
+        embedding.
+
+    Returns
+    -------
+    embedding: list[float]
+        The resulting embedding with the desired type.
+    """
+    x = x.strip("[]")
+    x_i = x.split(",")
+    embedding = [float(i) for i in x_i]
+    return embedding
+
+
+def str_to_word_embedding(x: str) -> list[list[float]]:
+    """
+    Converts a string into a list of lists of floats. Helps read word
+    embeddings off a TSV file.
+
+    Parameters
+    ----------
+    x: str The str that we wish to convert to a readable word embedding.
+
+    Returns
+    -------
+    embedding: list[list[[float]]
+        The resulting embedding with the desired type.
+    """
+    x = x.strip("[]")
+    x_lists = x.split("], [")
+    float_lists = []
+    for sublist_str in x_lists:
+        sublist_str = sublist_str.strip("[]")
+        float_strings = sublist_str.split(",")
+        float_sublist = [float(float_str) for float_str in float_strings]
+        float_lists.append(float_sublist)
+
+    return float_lists
+
+
+# Define unit tests
+
+
+class TestEmbedder(unittest.TestCase):
+    def setUp(self):
+        """
+        Load test dataset to perform our tests on.
+        """
+
+        self.dataset = pd.read_csv(
+            dataset_path + "amazonreview_train.tsv", delimiter="\t", nrows=5
+        )
+
+    def testBertSentenceUncasedDim(self):
+        """
+        Test that the dimension of the BERT uncased model sentence
+        embeddings is 768.
+        """
+        dim_bert = 768
+        sentence_embeddings_df = Bert(self.dataset).compute_embeddings()
+        embeddings_list = list(sentence_embeddings_df["sentence_vectorised"])
+        for embedding in embeddings_list:
+            self.assertEqual(len(embedding), dim_bert)
+
+    def testBertSentenceCasedDim(self):
+        """
+        Test that the dimension of the BERT cased model sentence
+        embeddings is 768.
+        """
+        dim_bert = 768
+        sentence_embeddings_df = Bert(
+            self.dataset, cased_or_uncased=True
+        ).compute_embeddings()
+        embeddings_list = list(sentence_embeddings_df["sentence_vectorised"])
+        for embedding in embeddings_list:
+            self.assertEqual(len(embedding), dim_bert)
+
+    def testBertWordUncasedDim(self):
+        """
+        Test that the dimension of the BERT uncased model word
+        embeddings is 768.
+        """
+        dim_bert = 768
+        word_embeddings_df = Bert(
+            self.dataset, sentence_or_word=False
+        ).compute_embeddings()
+        embeddings_list = list(word_embeddings_df["sentence_vectorised"])
+        for vector in embeddings_list:
+            for embedding in vector:
+                self.assertEqual(len(embedding), dim_bert)
+
+    def testBertWordCasedDim(self):
+        """
+        Test that the dimension of the BERT cased model word embeddings
+        is 768.
+        """
+        dim_bert = 768
+        word_embeddings_df = Bert(
+            self.dataset, cased_or_uncased=True, sentence_or_word=False
+        ).compute_embeddings()
+        embeddings_list = list(word_embeddings_df["sentence_vectorised"])
+        for vector in embeddings_list:
+            for embedding in vector:
+                self.assertEqual(len(embedding), dim_bert)
+
+    def testBertSentenceCasedUncased(self):
+        """
+        Test that the cased and uncased models of Bert generate
+        different sentence embeddings for the same sentence.
+        """
+        uncased_embeddings_df = Bert(self.dataset).compute_embeddings()
+        cased_embeddings_df = Bert(
+            self.dataset, cased_or_uncased=True
+        ).compute_embeddings()
+        uncased_embeddings_list = list(uncased_embeddings_df["sentence_vectorised"])
+        cased_embeddings_list = list(cased_embeddings_df["sentence_vectorised"])
+        for i in range(len(uncased_embeddings_list)):
+            self.assertNotEqual(uncased_embeddings_list[i], cased_embeddings_list[i])
+
+    def testBertWordCasedUncased(self):
+        """
+        Test that the cased and uncased models of Bert generate
+        different word embeddings for the same words.
+        """
+        uncased_embeddings_df = Bert(
+            self.dataset, sentence_or_word=False
+        ).compute_embeddings()
+        cased_embeddings_df = Bert(
+            self.dataset, sentence_or_word=False, cased_or_uncased=True
+        ).compute_embeddings()
+        uncased_embeddings_list = list(uncased_embeddings_df["sentence_vectorised"])
+        cased_embeddings_list = list(cased_embeddings_df["sentence_vectorised"])
+        for i in range(len(uncased_embeddings_list)):
+            self.assertNotEqual(uncased_embeddings_list[i], cased_embeddings_list[i])
+
+    def testFastTextSentenceDim(self):
+        """
+        Tests that the generated FastText sentence embeddings have
+        dimension = 300, which is the FastText standard output
+        dimension. Note that there is no need to try cased and uncased
+        scenarios separately as in FastText the pretrained model is
+        cased and so the choice of cased or uncased only affects the
+        casefolding of the input, and has no impact on the output
+        dimension of the embeddings that are generated.
+        """
+        dim_ft = 300
+        sentence_embeddings_df = FastText(self.dataset).compute_embeddings()
+        embeddings_list = list(sentence_embeddings_df["sentence_vectorised"])
+        for embedding in embeddings_list:
+            self.assertEqual(len(embedding), dim_ft)
+
+    def testFastTextWordDim(self):
+        """
+        Tests that the generated FastText word embeddings have
+        dimension = 300, which is the FastText standard output
+        dimension. Note that there is no need to try cased and uncased
+        scenarios separately as in FastText the pretrained model is
+        cased and so the choice of cased or uncased only affects the
+        casefolding of the input, and has no impact on the output
+        dimension of the embeddings that are generated.
+        """
+        dim_ft = 300
+        word_embeddings_df = FastText(
+            self.dataset, sentence_or_word=False
+        ).compute_embeddings()
+        embeddings_list = list(word_embeddings_df["sentence_vectorised"])
+        for vector in embeddings_list:
+            for embedding in vector:
+                self.assertEqual(len(embedding), dim_ft)
+
+    def testFastTextSentenceDimReduction(self):
+        """
+        Tests that FastText's tool for reducing the dimension of the
+        sentence embeddings works for a random dimension in the range
+        [1, 299].
+        """
+        out_dim = random.randint(1, 299)
+        sentence_embeddings_df = FastText(
+            self.dataset, dim=out_dim
+        ).compute_embeddings()
+        embeddings_list = list(sentence_embeddings_df["sentence_vectorised"])
+        for embedding in embeddings_list:
+            self.assertEqual(len(embedding), out_dim)
+
+    def testFastTextWordDimReduction(self):
+        """
+        Tests that FastText's tool for reducing the dimension of the
+        word embeddings works for a random dimension in the range [1,
+        299].
+        """
+        out_dim = random.randint(1, 299)
+        sentence_embeddings_df = FastText(
+            self.dataset, sentence_or_word=False, dim=out_dim
+        ).compute_embeddings()
+        embeddings_list = list(sentence_embeddings_df["sentence_vectorised"])
+        for vector in embeddings_list:
+            for embedding in vector:
+                self.assertEqual(len(embedding), out_dim)
+
+    def testReadSavedSentenceBertEmbeddings(self):
+        """
+        Tests whether the BERT sentence embeddings in the saved TSV
+        dataset can be read as lists without issues.
+        """
+        path = "./"
+        filename = "test_sentence_embeddings"
+        embedder = Bert(self.dataset)
+        embedder.compute_embeddings()
+        embedder.save_embedding_dataset(path, filename)
+        saved_sentence_embedding_df = pd.read_csv(
+            path + filename + ".tsv", sep="\t", header=0
+        )
+        sentence_embeddings_list = saved_sentence_embedding_df["sentence_vectorised"]
+        for vector in sentence_embeddings_list:
+            self.assertTrue(is_sentence_embedding(str_to_sentence_embedding(vector)))
+
+        file_path = path + filename + ".tsv"
+        if os.path.exists(file_path):
+            os.remove(file_path)
+
+    def testReadSavedWordBertEmbeddings(self):
+        """
+        Tests whether the BERT word embeddings in the saved TSV
+        dataset can be read as lists without issues.
+        """
+        path = "./"
+        filename = "test_word_embeddings"
+        embedder = Bert(self.dataset, sentence_or_word=False)
+        embedder.compute_embeddings()
+        embedder.save_embedding_dataset(path, filename)
+        saved_word_embedding_df = pd.read_csv(
+            path + filename + ".tsv", sep="\t", header=0
+        )
+        word_embeddings_list = saved_word_embedding_df["sentence_vectorised"]
+        for vector in word_embeddings_list:
+            self.assertTrue(is_word_embedding(str_to_word_embedding(vector)))
+
+        file_path = path + filename + ".tsv"
+        if os.path.exists(file_path):
+            os.remove(file_path)
+
+    def testReadSavedFastTextSentenceEmbeddings(self):
+        """
+        Tests whether the FastText sentence embeddings in the saved TSV
+        datasets can be read as lists without issues.
+        """
+        path = "./"
+        filename = "test_sentence_embeddings"
+        embedder = FastText(self.dataset)
+        embedder.compute_embeddings()
+        embedder.save_embedding_dataset(path, filename)
+        saved_sentence_embedding_df = pd.read_csv(
+            path + filename + ".tsv", sep="\t", header=0
+        )
+        sentence_embeddings_list = saved_sentence_embedding_df["sentence_vectorised"]
+        for vector in sentence_embeddings_list:
+            self.assertTrue(is_sentence_embedding(str_to_sentence_embedding(vector)))
+
+        file_path = path + filename + ".tsv"
+        if os.path.exists(file_path):
+            os.remove(file_path)
+
+    def testReadSavedFastTextWordEmbeddings(self):
+        """
+        Tests whether the FastText word embeddings in the saved TSV
+        datasets can be read as lists without issues.
+        """
+        path = "./"
+        filename = "test_word_embeddings"
+        embedder = FastText(self.dataset, sentence_or_word=False)
+        embedder.compute_embeddings()
+        embedder.save_embedding_dataset(path, filename)
+        saved_word_embedding_df = pd.read_csv(
+            path + filename + ".tsv", sep="\t", header=0
+        )
+        word_embeddings_list = saved_word_embedding_df["sentence_vectorised"]
+        for vector in word_embeddings_list:
+            self.assertTrue(is_word_embedding(str_to_word_embedding(vector)))
+
+        file_path = path + filename + ".tsv"
+        if os.path.exists(file_path):
+            os.remove(file_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope
This PR introduces the embedder module for the new experiment pipeline to the repository. It also includes the unit tests associated to this module and updates the poetry .toml dependencies file to include FastText.


## Implementation
The embedder module consists of an abstract base class called Embedder. Then two child classes are derived, Bert and FastText. These classes are used to read a dataset with natural language data and convert the sentences into their BERT/FastText vectorised counterparts. 

## How to Test
Use a toy dataset and play around with the different attributes and methods of these classes. There are only two methods: compute_embeddings loads the data onto a pandas dataframe, vectorises the data and then adds this onto a new column of the dataset, returning the updated dataframe with the vectorised data, and save_embeddings_dataset writes this dataframe onto a TSV file. Unit tests can be ran by running test_embedder.py located in the tests directory.